### PR TITLE
Convert IP addresses to text strings

### DIFF
--- a/lib/Crypt/PKCS10.pm
+++ b/lib/Crypt/PKCS10.pm
@@ -483,6 +483,22 @@ sub subject {
     return $subj;
 }
 
+sub subjectAltName {
+    my $self = shift;
+    my( $type ) = @_;
+
+    my $san = $self->extensionValue( 'subjectAltName' );
+    unless( defined $san && defined $type ) {
+	return () if( wantarray );
+	return undef;
+    }
+
+    my $result = [ map { $_->{$type} } grep { exists $_->{$type} } @$san ];
+
+    return @$result if( wantarray );
+    return $result->[0];
+}
+
 sub version {
     my $self = shift;
     my $v = $self->{'certificationRequestInfo'}{'version'};
@@ -588,7 +604,7 @@ Crypt::PKCS10 - parse PKCS #10 certificate requests
     use Crypt::PKCS10;
 
     my $decoded = Crypt::PKCS10->new( $csr );
-    my $cn = $decoded->commonName();
+    my $subject = $decoded->subject;
 
 =head1 REQUIRES
 
@@ -663,6 +679,29 @@ In array context, returns an array of (componentName, [values]) pairs.  Abbrevia
 
 Note that the order of components in a name is significant.
 
+=head2 subjectAltName($type)
+
+Convenience method.
+
+Returns the subject alternate name values of the specified type in list context, or the first value
+of the specified type in scalar context.
+
+Returns undefined/empty list if no values of the specified type are present, or if the subjectAltName
+extension is not present.
+
+Types can be any of:
+
+   otherName
+ * rfc822Name
+ * dNSName
+   x400Address
+   directoryName
+   ediPartyName
+ * uniformResourceIdentifier
+ * iPAddress
+ * registeredID
+
+The types marked with '*' are the most common.
 
 =head2 version
 

--- a/lib/Crypt/PKCS10.pm
+++ b/lib/Crypt/PKCS10.pm
@@ -274,6 +274,20 @@ sub _mapExtensions {
         foreach my $entry (@{$value}) {
             $entry->{'policyIdentifier'} = $oid2extkeyusage{$entry->{'policyIdentifier'}} if(defined $oid2extkeyusage{$entry->{'policyIdentifier'}});
         }
+    } elsif (ref $value->[0] eq 'HASH') {
+	foreach my $entry (@{$value}) {
+	    if( exists $entry->{iPAddress} ) {
+		use bytes;
+		my $addr = $entry->{iPAddress};
+		if( length $addr == 4 ) {
+		    $entry->{iPAddress} = sprintf( '%vd', $entry->{iPAddress} );
+		} else {
+		    $addr = sprintf( '%*v02X', ':', $addr );
+		    $addr =~ s/([[:xdigit:]]{2}):([[:xdigit:]]{2})/$1$2/g;
+		    $entry->{iPAddress} = $addr;
+		}
+	    }
+	}
     }
     return $value
 }

--- a/lib/Crypt/PKCS10.pm
+++ b/lib/Crypt/PKCS10.pm
@@ -280,7 +280,7 @@ sub _mapExtensions {
 		use bytes;
 		my $addr = $entry->{iPAddress};
 		if( length $addr == 4 ) {
-		    $entry->{iPAddress} = sprintf( '%vd', $entry->{iPAddress} );
+		    $entry->{iPAddress} = sprintf( '%vd', $addr );
 		} else {
 		    $addr = sprintf( '%*v02X', ':', $addr );
 		    $addr =~ s/([[:xdigit:]]{2}):([[:xdigit:]]{2})/$1$2/g;


### PR DESCRIPTION
Currently IP addresses are exported as binary strings.  They are more useful in text form, and it's easier to convert text to binary than the other way around.  Also, this ensures that the binary encoding trick used by the ASN.1 remains inside Crypt::PKCS10.

The text form of IPv6 addresses is fully expanded (no :: abbreviations).  It's easiest to generate, and most useful for comparisons.  Standard modules such as Net::IP can be used to get the abbreviated format if desired.

Standard functions such as inet_pton and getaddrinfo can convert the text into the binary encodings if desired.

For example (assuming the subjectAltName hack persists):
````
x $csr->subjectAltName('iPAddress')
0  '10.2.3.4'
1  '2001:0DB8:0741:0000:0000:0000:0000:0000'
````
The arguments for text are:
 Consistency with other fields (e.g. the key usages) 
 Addresses are likely to be displayed or logged.
 Addresses are likely to be fed into certificates via OpenSSL configs (e.g. via Crypt::OpenSSL::CA), which expects text form.
 Distinguishing IPv4 from IPv6 in the binary requires knowledge that the ASN.1 spec uses the length to decide which address form is encoded.

The only argument against is that previous versions of the module used binary, so this is an incompatible change to the API.
